### PR TITLE
Port to Pharo 11 maintaining Pharo 8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ With Vizor you can:
  - leverage predefined view specifications or create custom ones to visualize a subset of the nodes and edges
  - ...
 
-Vizor is developed in [Pharo](https://pharo.org), tested with Pharo 8, and released under MIT License.
+Vizor is developed in [Pharo](https://pharo.org), tested and usable with Pharo 8 and 11, and released under MIT License.
 
 ## Installation and Usage
 

--- a/src/BaselineOfVizor/BaselineOfVizor.class.st
+++ b/src/BaselineOfVizor/BaselineOfVizor.class.st
@@ -8,9 +8,11 @@ Class {
 BaselineOfVizor >> baseline: spec [
 	<baseline>
 	spec for: #common do: [
-		"Dependencies"
-		self roassal3: spec.
-		self roassal3Exporters: spec.
+		spec for: #'pharo8.x' do: [
+			"Pharo 8 Dependencies (Roassal)"
+			self roassal3: spec.
+			self roassal3Exporters: spec.
+		].
 
 		"Packages"
 		spec

--- a/src/BaselineOfVizor/BaselineOfVizor.class.st
+++ b/src/BaselineOfVizor/BaselineOfVizor.class.st
@@ -11,8 +11,9 @@ BaselineOfVizor >> baseline: spec [
 		spec for: #'pharo8.x' do: [
 			"Pharo 8 Dependencies (Roassal)"
 			self roassal3: spec.
-			self roassal3Exporters: spec.
 		].
+	
+		self roassal3Exporters: spec.
 
 		"Packages"
 		spec

--- a/src/Vizor-GUI/VZComponent.class.st
+++ b/src/Vizor-GUI/VZComponent.class.st
@@ -32,7 +32,9 @@ VZComponent >> monitor [
 { #category : #showing }
 VZComponent >> openWithSpec [
 	"For compatibility with older version of Roassal"
-	self open.
+	((((Smalltalk version splitOn: $.) at: 1) withoutPrefix: 'Pharo') asInteger >= 11)
+		ifTrue: [ self open. ]
+		ifFalse: [ super openWithSpec. ].
 ]
 
 { #category : #dependencies }

--- a/src/Vizor-GUI/VZComponent.class.st
+++ b/src/Vizor-GUI/VZComponent.class.st
@@ -29,6 +29,12 @@ VZComponent >> monitor [
 	^ self mainWindow monitor.
 ]
 
+{ #category : #showing }
+VZComponent >> openWithSpec [
+	"For compatibility with older version of Roassal"
+	self open.
+]
+
 { #category : #dependencies }
 VZComponent >> release [
 	self class instVarNames do: [ :name | self instVarNamed: name put: nil ].

--- a/src/Vizor-GUI/VZGlyph.class.st
+++ b/src/Vizor-GUI/VZGlyph.class.st
@@ -157,7 +157,9 @@ VZGlyph >> mapMetricsToProperties [
 
 { #category : #interacting }
 VZGlyph >> openContextMenu [
-	self contextMenu openWithSpecAt: ActiveHand position
+((((Smalltalk version splitOn: $.) at: 1) withoutPrefix: 'Pharo') asInteger >= 11)
+	ifTrue: [ self contextMenu openWithSpecAtPointer ]
+	ifFalse: [ self contextMenu openWithSpecAt: ActiveHand position ].
 ]
 
 { #category : #'private - utility' }

--- a/src/Vizor-GUI/VZRoassalCanvasRenderer.class.st
+++ b/src/Vizor-GUI/VZRoassalCanvasRenderer.class.st
@@ -21,7 +21,7 @@ VZRoassalCanvasRenderer class >> defaultLayout [
 { #category : #interacting }
 VZRoassalCanvasRenderer >> addCanvasInteractions [
 	highlighter := RSHighlightable red.
-	elasticBox := RSElasticBox new.
+	elasticBox := ((((Smalltalk version splitOn: $.) at: 1) withoutPrefix: 'Pharo') asInteger >= 11) ifTrue: [ RSElasticBoxInteraction new ] ifFalse: [ RSElasticBox new ].
 	elasticBox
 		when: RSSelectionStartEvent do: [ :evt |
 			highlighter unhighlightRecordedShapes: evt canvas ];

--- a/src/Vizor-GUI/VZWorldMenu.class.st
+++ b/src/Vizor-GUI/VZWorldMenu.class.st
@@ -39,13 +39,13 @@ VZWorldMenu class >> menu01ExamplesOn: aBuilder [
 ]
 
 { #category : #menu }
-VZWorldMenu class >> menu03GitlabOn: aBuilder [
+VZWorldMenu class >> menu03GithubOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #VizorGit)
 		parent: #VZMonitor;
 		order: 3;
-		label: 'GitLab';
-		help: 'Open Vizor GitLab page';
-		icon: (self iconNamed: 'gitlab');
-		action: [ WebBrowser openOn: 'https://gitlab.reveal.si.usi.ch/research/vizor/' ].
+		label: 'GitHub';
+		help: 'Open Vizor GitHub page';
+		icon: (self iconNamed: 'github');
+		action: [ WebBrowser openOn: 'https://github.com/USIREVEAL/Vizor' ].
 ]


### PR DESCRIPTION
Adapt and test Vizor to be used in Pharo 11 where Roassal is by default already in the system (and there is an updated version of Roassal mainly with some names changed).

Also update documentation link to correctly point to GitHub.